### PR TITLE
Remove version from show-plugin btest in prep for 2.7

### DIFF
--- a/tests/Baseline/netmap.show-plugin/output
+++ b/tests/Baseline/netmap.show-plugin/output
@@ -1,4 +1,4 @@
-Bro::Netmap - Packet acquisition via Netmap (dynamic, version 1.0)
+Bro::Netmap - Packet acquisition via Netmap (dynamic, version)
     [Packet Source] NetmapReader (interface prefix "netmap"; supports live input)
     [Packet Source] NetmapReader (interface prefix "vale"; supports live input)
 

--- a/tests/netmap/show-plugin.bro
+++ b/tests/netmap/show-plugin.bro
@@ -1,2 +1,2 @@
-# @TEST-EXEC: bro -NN Bro::Netmap >output
+# @TEST-EXEC: bro -NN Bro::Netmap |sed -e 's/version.*)/version)/g' >output
 # @TEST-EXEC: btest-diff output


### PR DESCRIPTION
Update show-plugin.bro test to remove the version number from the baseline output.
With Bro 2.7, the version will be built from major.minor.patch, which conflicts with
the current major.minor in the baseline.