### PR TITLE
Zeek 4.1 modernization

### DIFF
--- a/configure.plugin
+++ b/configure.plugin
@@ -14,7 +14,11 @@ plugin_option()
 {
     case "$1" in
         --with-netmap=*)
-            append_cache_entry NETMAP_ROOT_DIR PATH $optarg
+            # With an empty value, the user might have skipped the zkg
+            # user_var input, so ignore then:
+            if [ -n "$optarg" ]; then
+                append_cache_entry NETMAP_ROOT_DIR PATH $optarg
+            fi
             return 0
             ;;
 

--- a/src/Netmap.cc
+++ b/src/Netmap.cc
@@ -1,8 +1,7 @@
-
-#include "zeek-config.h"
+#include <zeek/zeek-config.h>
 #include "Netmap.h"
 
-using namespace iosource::pktsrc;
+using namespace ZEEK_IOSOURCE_NS::pktsrc;
 
 NetmapSource::~NetmapSource()
 	{
@@ -126,12 +125,12 @@ void NetmapSource::Statistics(Stats* s)
 	s->dropped = nd->st.ps_drop + nd->st.ps_ifdrop;
 	}
 
-iosource::PktSrc* NetmapSource::InstantiateNetmap(const std::string& path, bool is_live)
+ZEEK_IOSOURCE_NS::PktSrc* NetmapSource::InstantiateNetmap(const std::string& path, bool is_live)
 	{
 	return new NetmapSource(path, is_live, "netmap");
 	}
 
-iosource::PktSrc* NetmapSource::InstantiateVale(const std::string& path, bool is_live)
+ZEEK_IOSOURCE_NS::PktSrc* NetmapSource::InstantiateVale(const std::string& path, bool is_live)
 	{
 	return new NetmapSource(path, is_live, "vale");
 	}

--- a/src/Netmap.h
+++ b/src/Netmap.h
@@ -1,7 +1,7 @@
 // See the file "COPYING" in the main distribution directory for copyright.
 
-#ifndef IOSOURCE_PKTSRC_NETMAP_SOURCE_H
-#define IOSOURCE_PKTSRC_NETMAP_SOURCE_H
+#ifndef ZEEK_NETMAP_NETMAP_H
+#define ZEEK_NETMAP_NETMAP_H
 
 extern "C" {
 #include <pcap.h>
@@ -9,10 +9,10 @@ extern "C" {
 #include <net/netmap_user.h>
 }
 
-#include "iosource/PktSrc.h"
+#include <zeek/iosource/PktSrc.h>
+#include "zeek-compat.h"
 
-namespace iosource {
-namespace pktsrc {
+namespace ZEEK_IOSOURCE_NS::pktsrc {
 
 class NetmapSource : public iosource::PktSrc {
 public:
@@ -62,7 +62,6 @@ private:
 	const u_char* last_data;
 };
 
-}
 }
 
 #endif

--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -1,18 +1,21 @@
+#include <zeek/iosource/Component.h>
 
 #include "Plugin.h"
 #include "Netmap.h"
-#include <iosource/Component.h>
 
-namespace plugin { namespace Zeek_Netmap { Plugin plugin; } }
+namespace ZEEK_PLUGIN_NS { namespace Zeek_Netmap { Plugin plugin; } }
 
-using namespace plugin::Zeek_Netmap;
+using namespace ZEEK_PLUGIN_NS::Zeek_Netmap;
+using namespace ZEEK_IOSOURCE_NS;
 
-plugin::Configuration Plugin::Configure()
+ZEEK_PLUGIN_NS::Configuration Plugin::Configure()
 	{
-	AddComponent(new ::iosource::PktSrcComponent("NetmapReader", "netmap", ::iosource::PktSrcComponent::LIVE, ::iosource::pktsrc::NetmapSource::InstantiateNetmap));
-	AddComponent(new ::iosource::PktSrcComponent("NetmapReader", "vale", ::iosource::PktSrcComponent::LIVE, ::iosource::pktsrc::NetmapSource::InstantiateVale));
+	AddComponent(new PktSrcComponent("NetmapReader", "netmap", PktSrcComponent::LIVE,
+					 pktsrc::NetmapSource::InstantiateNetmap));
+	AddComponent(new PktSrcComponent("NetmapReader", "vale", PktSrcComponent::LIVE,
+					 pktsrc::NetmapSource::InstantiateVale));
 
-	plugin::Configuration config;
+	ZEEK_PLUGIN_NS::Configuration config;
 	config.name = "Zeek::Netmap";
 	config.description = "Packet acquisition via Netmap";
 	config.version.major = 1;

--- a/src/Plugin.h
+++ b/src/Plugin.h
@@ -1,17 +1,18 @@
 
-#ifndef ZEEK_PLUGIN_ZEEK_NETMAP
-#define ZEEK_PLUGIN_ZEEK_NETMAP
+#ifndef ZEEK_NETMAP_PLUGIN_H
+#define ZEEK_NETMAP_PLUGIN_H
 
-#include <plugin/Plugin.h>
+#include <zeek/plugin/Plugin.h>
+#include "zeek-compat.h"
 
-namespace plugin {
+namespace ZEEK_PLUGIN_NS {
 namespace Zeek_Netmap {
 
-class Plugin : public ::plugin::Plugin
+class Plugin : public ZEEK_PLUGIN_NS::Plugin
 {
 protected:
 	// Overridden from plugin::Plugin.
-	virtual plugin::Configuration Configure();
+	virtual ZEEK_PLUGIN_NS::Configuration Configure();
 };
 
 extern Plugin plugin;

--- a/src/zeek-compat.h
+++ b/src/zeek-compat.h
@@ -1,0 +1,22 @@
+#ifndef ZEEK_NETMAP_COMPAT_H
+#define ZEEK_NETMAP_COMPAT_H
+
+#include <zeek/zeek-config.h>
+
+#if ZEEK_VERSION_NUMBER >= 30100 && ZEEK_VERSION_NUMBER < 30200
+
+#define ZEEK_PLUGIN_NS plugin
+#define ZEEK_IOSOURCE_NS iosource
+
+#elif ZEEK_VERSION_NUMBER >= 30200 && ZEEK_VERSION_NUMBER < 40000
+
+#define ZEEK_PLUGIN_NS zeek::plugin
+#define ZEEK_IOSOURCE_NS iosource
+
+#elif ZEEK_VERSION_NUMBER >= 40000
+
+#define ZEEK_PLUGIN_NS zeek::plugin
+#define ZEEK_IOSOURCE_NS zeek::iosource
+
+#endif
+#endif

--- a/zkg.meta
+++ b/zkg.meta
@@ -2,5 +2,8 @@
 description = Packet source plugin that provides native Netmap support.
 tags = packet source, plugin, netmap
 plugin_dir = build
-build_command = ./configure && cd build && make
+build_command = ./configure --with-netmap=%(netmap_root_dir)s && cd build && make
 test_command = cd tests && btest -d -c btest.cfg
+
+user_vars =
+    netmap_root_dir [] "Root directory of Netmap installation"

--- a/zkg.meta
+++ b/zkg.meta
@@ -4,6 +4,7 @@ tags = packet source, plugin, netmap
 plugin_dir = build
 build_command = ./configure --with-netmap=%(netmap_root_dir)s && cd build && make
 test_command = cd tests && btest -d -c btest.cfg
-
+depends =
+  zeek >=3.1.0
 user_vars =
     netmap_root_dir [] "Root directory of Netmap installation"


### PR DESCRIPTION
This makes the package install with Zeek 3.1 or newer, up to current master. It also requires Zeek 3.1+ in `zkg.meta`. Zeek 3.0.x doesn't yet have the `ZEEK_VERSION_NUMBER` definition in zeek-config.h, and since 4.0 is now out, I don't think we need to support 3.0.x any longer.

This also adds support for specifying the Netmap install root via a user variable in zkg. The default is empty, and you can keep it that way — in that case it falls back to looking internally (which means `/usr` and `/usr/local`).

I've tested this with my local builds but a double-check would be much appreciated.