### PR TITLE
Add bytes_received tracking in stats and expose it to Statistics() callers

### DIFF
--- a/src/Netmap.cc
+++ b/src/Netmap.cc
@@ -87,6 +87,7 @@ bool NetmapSource::ExtractNextPacket(Packet* pkt)
 
 		pkt->Init(props.link_type, &current_hdr.ts, current_hdr.caplen, current_hdr.len, data);
 		++stats.received;
+		stats.bytes_received += current_hdr.len;
 		return true;
 		}
 
@@ -119,6 +120,7 @@ void NetmapSource::Statistics(Stats* s)
 		}
 
 	s->received = stats.received;
+	s->bytes_received = stats.bytes_received;
 	s->link = stats.received + num_discarded;
 
 	// TODO: Seems these counters aren't actually set?


### PR DESCRIPTION
We're using bytes_received at a script level through get_net_stats(), but the Netmap packet source does not provide it currently.

@sethhall / @ckreibich - is this something you could pick up?